### PR TITLE
Better connection pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ tags
 
 # Don't commit folder with temp data
 /tmp/
+
+cover.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ go:
 - tip
 
 before_install:
+  - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
   - docker run --detach --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j
 
 # jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,17 @@ os:
   - osx
 
 go:
-- 1.4.3
-- 1.5.4
-- 1.6.4
 - 1.7.4
 - tip
+
+jdk:
+  - oraclejdk7
+before_install:
+  # install Neo4j locally:
+  - wget dist.neo4j.org/neo4j-community-3.1.0-unix.tar.gz
+  - tar -xzf neo4j-community-3.1.0-unix.tar.gz
+  - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-3.1.0/conf/neo4j-server.properties
+  - neo4j-community-3.1.0/bin/neo4j start
 
 #before_install:
 #- go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,12 @@ language: go
 services:
   - docker
 
-os:
-  - linux
-  - osx
-
 go:
 - 1.7.4
 - tip
 
 before_install:
-  - docker run --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j
+  - docker run --detach --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j
 
 # jdk:
 #   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ before_install:
   - echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
   - docker run --detach --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j
 
+script:
+  - go build ./...
+  - BOLT_DRIVER_LOG=info NEO4J_BOLT=bolt://localhost:7687 go test -coverprofile=cover.out -coverpkg=./... -v -race
+
 # jdk:
 #   - oraclejdk7
 # before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+sudo: required
+
 language: go
 
-sudo: false
+services:
+  - docker
 
 os:
   - linux
@@ -10,14 +13,17 @@ go:
 - 1.7.4
 - tip
 
-jdk:
-  - oraclejdk7
 before_install:
-  # install Neo4j locally:
-  - wget dist.neo4j.org/neo4j-community-3.1.0-unix.tar.gz
-  - tar -xzf neo4j-community-3.1.0-unix.tar.gz
-  - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-3.1.0/conf/neo4j-server.properties
-  - neo4j-community-3.1.0/bin/neo4j start
+  - docker run --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j
+
+# jdk:
+#   - oraclejdk7
+# before_install:
+#   # install Neo4j locally:
+#   - wget dist.neo4j.org/neo4j-community-3.1.0-unix.tar.gz
+#   - tar -xzf neo4j-community-3.1.0-unix.tar.gz
+#   - sed -i.bak s/dbms.security.auth_enabled=true/dbms.security.auth_enabled=false/g neo4j-community-3.1.0/conf/neo4j-server.properties
+#   - neo4j-community-3.1.0/bin/neo4j start
 
 #before_install:
 #- go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Golang Neo4J Bolt Driver
-[![Build Status](https://travis-ci.org/johnnadratowski/golang-neo4j-bolt-driver.svg?branch=master)](https://travis-ci.org/johnnadratowski/golang-neo4j-bolt-driver) *Tested against Golang 1.4.3 and up*
+[![Build Status](https://travis-ci.org/axiomzen/golang-neo4j-bolt-driver.svg?branch=master)](https://travis-ci.org/axiomzen/golang-neo4j-bolt-driver) *Tested against Golang 1.4.3 and up*
 
 
 Implements the Neo4J Bolt Protocol specification:
 As of the time of writing this, the current version is v3.1.0-M02
 
 ```
-go get github.com/johnnadratowski/golang-neo4j-bolt-driver
+go get github.com/axiomzen/golang-neo4j-bolt-driver
 ```
 
 ## Features
@@ -194,7 +194,7 @@ func slowNClean() {
 ```
 ## API
 
-*_There is much more detailed information in [the godoc](http://godoc.org/github.com/johnnadratowski/golang-neo4j-bolt-driver)_*
+*_There is much more detailed information in [the godoc](http://godoc.org/github.com/axiomzen/golang-neo4j-bolt-driver)_*
 
 This implementation attempts to follow the best practices as per the Bolt specification, but also implements compatibility with Golang's `sql.driver` interface.
 
@@ -205,8 +205,7 @@ It is recommended that you use the Neo4j Bolt-specific interfaces if possible.  
 The URL format is: `bolt://(user):(password)@(host):(port)`
 Schema must be `bolt`. User and password is only necessary if you are authenticating.
 
-Connection pooling is provided out of the box with the `NewDriverPool` method.  You can give it the maximum number of
-connections to have at a time.
+Connection pooling is provided out of the box with the `NewDriverPool` method.  A bunch of options (use `DefaultPoolOptions` for defaults)
 
 You can get logs from the driver by setting the log level using the `log` packages `SetLevel`.
 
@@ -236,6 +235,10 @@ The tests are written in an integration testing style.  Most of them are in the 
 In order to get CI, I made a recorder mechanism so you don't need to run neo4j alongside the tests in the CI server.  You run the tests locally against a neo4j instance with the RECORD_OUTPUT=1 environment variable, it generates the recordings in the ./recordings folder.  This is necessary if the tests have changed, or if the internals have significantly changed.  Installing the git hooks will run the tests automatically on push.  If there are updated tests, you will need to re-run the recorder to add them and push them as well.
 
 You need access to a running Neo4J database to develop for this project, so that you can run the tests to generate the recordings.
+
+Easiest way is with docker:
+
+`docker run --publish=7474:7474 --publish=7687:7687 --env=NEO4J_AUTH=none --volume=$HOME/neo4j/data:/data neo4j`
 
 ## TODO
 

--- a/conn.go
+++ b/conn.go
@@ -48,8 +48,6 @@ type Conn interface {
 	// ExecPipeline executes a query using the neo4j-specific interface
 	// pipelining multiple statements
 	ExecPipeline(query []string, params ...map[string]interface{}) ([]Result, error)
-	// Close closes the connection
-	//Close() error
 	// Begin starts a new transaction
 	Begin() (driver.Tx, error)
 	// SetChunkSize is used to set the max chunk size of the

--- a/conn.go
+++ b/conn.go
@@ -65,6 +65,7 @@ var ErrClosed = errors.New("connection is closed")
 
 // todo: add fields that are needed via the other one
 type boltConn struct {
+	// todo: perhaps move this to the driver instead
 	options       *DriverOptions
 	url           *url.URL
 	user          string
@@ -73,15 +74,10 @@ type boltConn struct {
 	connErr       error
 	serverVersion []byte
 	closed        bool
-	// TODO: figure out tls
-	tlsConfig *tls.Config
 
-	//certFile   string
-	//caCertFile string
-	//keyFile    string
-	//tlsNoVerify   bool
-	//poolDriver DriverPool
-	pooled bool
+	// todo: perhaps move this to the driver instead
+	tlsConfig *tls.Config
+	pooled    bool
 
 	transaction *boltTx
 	statement   *boltStmt
@@ -316,8 +312,6 @@ func (c *boltConn) handShake() error {
 
 	return nil
 }
-
-//type conFinder func(connStr string, d *boltDriver) (net.Conn, error)
 
 func (c *boltConn) initialize(d *boltDriver) error {
 

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-/*Package golangNeo4jBoltDriver implements a driver for the Neo4J Bolt Protocol.
+/*package bolt implements a driver for the Neo4J Bolt Protocol.
 
 The driver is compatible with Golang's sql.driver interface, but
 aims to implement a more complete featureset in line with what
@@ -92,4 +92,4 @@ If there is an error with the database connection, you should get a sql/driver E
 as per the best practice recommendations of the Golang SQL Driver. However, this error
 may be wrapped, so you might have to call `InnerMost` to get it, as specified above.
 */
-package golangNeo4jBoltDriver
+package bolt

--- a/driver.go
+++ b/driver.go
@@ -1,8 +1,13 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
+	"crypto/tls"
 	"database/sql"
 	"database/sql/driver"
+	"math"
+	"time"
+
+	"github.com/axiomzen/interpool"
 )
 
 var (
@@ -35,100 +40,124 @@ var (
 type Driver interface {
 	// Open opens a sql.driver compatible connection. Used internally
 	// by the go sql interface
-	Open(string) (driver.Conn, error)
+	Open(constr string) (driver.Conn, error)
 	// OpenNeo opens a Neo-specific connection. This should be used
 	// directly when not using the golang sql interface
-	OpenNeo(string) (Conn, error)
+	OpenNeo() (Conn, error)
+	// NewConnPool creates a new connection pool instead
+	NewConnPool(ops *PoolOptions) DriverPool
+}
+
+// DriverOptions are the options for the driver
+type DriverOptions struct {
+	// Dial timeout for establishing new connections.
+	// Default is 5 seconds.
+	DialTimeout time.Duration
+	// Timeout for socket reads. If reached, commands will fail
+	// with a timeout instead of blocking.
+	ReadTimeout time.Duration
+	// Timeout for socket writes. If reached, commands will fail
+	// with a timeout instead of blocking.
+	WriteTimeout time.Duration
+	// Addr is the connection string
+	Addr string
+	// TLSNoverify allows you to skip tls verification
+	// replaced by TLSConfig.InsecureSkipVerify
+	//TLSNoVerify bool
+	// TLSConfig is the tls configuration (nil by default)
+	TLSConfig *tls.Config
+	// PoolOptions are the options for the connection pool
+	//PoolOptions *PoolOptions
+	// ChunkSize is im not sure
+	ChunkSize uint16
+}
+
+// DefaultDriverOptions returns the default options
+func DefaultDriverOptions() *DriverOptions {
+	return &DriverOptions{
+		DialTimeout:  time.Second * 5,
+		ReadTimeout:  time.Second * 60,
+		WriteTimeout: time.Second * 60,
+		//TLSNoVerify:  false,
+		TLSConfig: nil,
+		ChunkSize: math.MaxUint16,
+	}
+}
+
+// DefaultPoolOptions returns the default connection pool options
+func DefaultPoolOptions() *PoolOptions {
+	return &PoolOptions{
+		PoolSize:           20,
+		PoolTimeout:        time.Second * 5,
+		IdleTimeout:        time.Hour,
+		IdleCheckFrequency: time.Minute,
+		MaxAge:             time.Hour * 24,
+	}
 }
 
 type boltDriver struct {
 	recorder *recorder
+	options  *DriverOptions
 }
 
-// NewDriver creates a new Driver object
+// NewDriver creates a new Driver object with defaults
 func NewDriver() Driver {
-	return &boltDriver{}
+	return NewDriverWithOptions(DefaultDriverOptions())
+}
+
+// NewDriverWithOptions creates a new Driver object with the given options
+func NewDriverWithOptions(options *DriverOptions) Driver {
+	return &boltDriver{
+		options: options,
+	}
 }
 
 // Open opens a new Bolt connection to the Neo4J database
-func (d *boltDriver) Open(connStr string) (driver.Conn, error) {
-	return newBoltConn(connStr, d) // Never use pooling when using SQL driver
+func (d *boltDriver) Open(constring string) (driver.Conn, error) {
+	if d.options == nil {
+		d.options = DefaultDriverOptions()
+		d.options.Addr = constring
+	}
+	return newBoltConn(d, false) // Never use pooling when using SQL driver
 }
 
 // Open opens a new Bolt connection to the Neo4J database. Implements a Neo-friendly alternative to sql/driver.
-func (d *boltDriver) OpenNeo(connStr string) (Conn, error) {
-	return newBoltConn(connStr, d)
+func (d *boltDriver) OpenNeo() (Conn, error) {
+	return newBoltConn(d, false)
 }
 
-// DriverPool is a driver allowing connection to Neo4j with support for connection pooling
-// The driver allows you to open a new connection to Neo4j
-//
-// Driver objects should be THREAD SAFE, so you can use them
-// to open connections in multiple threads.  The connection objects
-// themselves, and any prepared statements/transactions within ARE NOT
-// THREAD SAFE.
-type DriverPool interface {
-	// OpenPool opens a Neo-specific connection.
-	OpenPool() (Conn, error)
-	reclaim(*boltConn) error
-}
+func (d *boltDriver) NewConnPool(ops *PoolOptions) DriverPool {
+	iops := &interpool.Options{
+		ConnFactory: interpool.ConnFactoryFunc(func() (interpool.Conn, error) {
+			return newBoltConn(d, true)
+			//return createBoltCon(d.options), nil
+		}),
+		OnCloser: interpool.OnCloserFunc(func(c interpool.Conn) error {
+			// this allows you to send a message right before you close the connection
+			// close is only called on the remove call, or when closing all connections
 
-type boltDriverPool struct {
-	connStr  string
-	maxConns int
-	pool     chan *boltConn
-}
-
-// NewDriverPool creates a new Driver object with connection pooling
-func NewDriverPool(connStr string, max int) (DriverPool, error) {
-	d := &boltDriverPool{
-		connStr:  connStr,
-		maxConns: max,
-		pool:     make(chan *boltConn, max),
+			// I don't think its needed in our case
+			// check out what this is supposed to do
+			// need to cast to our con type
+			//oc, ok := c.(*boltConn)
+			// const terminateMsg        = 'X'
+			//var terminateMessage = []byte{terminateMsg, 0, 0, 0, 4}
+			//_, err := cn.NetConn().Write(terminateMessage)
+			//return nil
+			return nil
+		}),
+		PoolSize:           ops.PoolSize,
+		PoolTimeout:        ops.PoolTimeout,
+		IdleTimeout:        ops.IdleTimeout,
+		IdleCheckFrequency: ops.IdleCheckFrequency,
+		MaxAge:             ops.MaxAge,
 	}
 
-	for i := 0; i < max; i++ {
-		conn, err := newPooledBoltConn(connStr, d)
-		if err != nil {
-			return nil, err
-		}
-
-		d.pool <- conn
+	pool := &boltConnPool{
+		pool: interpool.NewConnPool(iops),
 	}
 
-	return d, nil
-}
-
-// OpenNeo opens a new Bolt connection to the Neo4J database.
-func (d *boltDriverPool) OpenPool() (Conn, error) {
-	conn := <-d.pool
-	if conn.conn == nil {
-		if err := conn.initialize(); err != nil {
-			return nil, err
-		}
-	}
-	return conn, nil
-}
-
-func (d *boltDriverPool) reclaim(conn *boltConn) error {
-	var newConn *boltConn
-	var err error
-	if conn.connErr != nil || conn.closed {
-		newConn, err = newPooledBoltConn(d.connStr, d)
-		if err != nil {
-			return err
-		}
-	} else {
-		// sneakily swap out connection so a reference to
-		// it isn't held on to
-		newConn = &boltConn{}
-		*newConn = *conn
-	}
-
-	d.pool <- newConn
-	conn = nil
-
-	return nil
+	return pool
 }
 
 func init() {

--- a/encoding/decoder.go
+++ b/encoding/decoder.go
@@ -5,9 +5,9 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/messages"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/messages"
 )
 
 // Decoder decodes a message from the bolt protocol stream

--- a/encoding/encoder.go
+++ b/encoding/encoder.go
@@ -7,8 +7,8 @@ import (
 
 	"bytes"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures"
 )
 
 const (

--- a/encoding/util.go
+++ b/encoding/util.go
@@ -1,8 +1,8 @@
 package encoding
 
 import (
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
 )
 
 func sliceInterfaceToString(from []interface{}) ([]string, error) {

--- a/examples/playground/playground.go
+++ b/examples/playground/playground.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/gob"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/encoding"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/encoding"
 	"math"
 )
 

--- a/examples/quick_n_dirty/quick_n_dirty.go
+++ b/examples/quick_n_dirty/quick_n_dirty.go
@@ -3,13 +3,15 @@ package main
 import (
 	"fmt"
 
-	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
+	"github.com/axiomzen/golang-neo4j-bolt-driver"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
 )
 
 func main() {
-	driver := bolt.NewDriver()
-	conn, _ := driver.OpenNeo("bolt://localhost:7687")
+	options := bolt.DefaultDriverOptions()
+	options.Addr = "bolt://localhost:7687"
+	driver := bolt.NewDriverWithOptions(options)
+	conn, _ := driver.OpenNeo()
 	defer conn.Close()
 
 	// Start by creating a node

--- a/examples/slow_n_clean/slow_n_clean.go
+++ b/examples/slow_n_clean/slow_n_clean.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"fmt"
-
-	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
 	"io"
+
+	"github.com/axiomzen/golang-neo4j-bolt-driver"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
 )
 
 func main() {
-	driver := bolt.NewDriver()
-	conn, err := driver.OpenNeo("bolt://localhost:7687")
+
+	options := bolt.DefaultDriverOptions()
+	options.Addr = "bolt://localhost:7687"
+	driver := bolt.NewDriverWithOptions(options)
+	conn, err := driver.OpenNeo()
+
 	if err != nil {
 		panic(err)
 	}

--- a/log/doc.go
+++ b/log/doc.go
@@ -2,5 +2,6 @@
 
 There are 3 logging levels - trace, info and error.  Setting trace would also set info and error logs.
 You can use the SetLevel("trace") to set trace logging, for example.
+The loggers & level are not thread safe so set the loggers and the level once in your app.
 */
 package log

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,81 @@
+package bolt
+
+import (
+	"io"
+	"time"
+
+	"github.com/axiomzen/golang-neo4j-bolt-driver/log"
+	"github.com/axiomzen/interpool"
+)
+
+// DriverPool is a driver allowing connection to Neo4j with support for connection pooling
+// The driver allows you to open a new connection to Neo4j
+//
+// DriverPool objects should be THREAD SAFE, so you can use them
+// to open connections in multiple threads.  The connection objects
+// themselves, and any prepared statements/transactions within ARE NOT
+// THREAD SAFE.
+type DriverPool interface {
+	io.Closer
+	// Get gets a connection from the pool
+	Get() (Conn, error)
+	// Put puts the connection back into the pool
+	// for later reuse
+	Put(Conn) error
+	// Closed lets you know if we are closed or not
+	Closed() bool
+}
+
+// PoolOptions are the options for the connection pool
+type PoolOptions struct {
+	PoolSize           int
+	PoolTimeout        time.Duration
+	IdleTimeout        time.Duration
+	IdleCheckFrequency time.Duration
+	MaxAge             time.Duration
+}
+
+type boltConnPool struct {
+	pool interpool.Pooler
+}
+
+// Close implements io.Closer and will close all the connections in the pool
+func (bcp *boltConnPool) Close() error {
+	st := bcp.pool.Stats()
+	if st.TotalConns != st.FreeConns {
+
+		log.Errorf(
+			"connection leaking detected: total_conns=%d free_conns=%d",
+			st.TotalConns, st.FreeConns,
+		)
+	}
+	return bcp.pool.Close()
+}
+
+// Closed implements DriverPool.Closed
+func (bcp *boltConnPool) Closed() bool {
+	return bcp.pool.Closed()
+}
+
+// Get implements DriverPool.Get
+func (bcp *boltConnPool) Get() (Conn, error) {
+	c, _, e := bcp.pool.Get()
+	ourc := c.(Conn)
+	return ourc, e
+	// should already come initialized from the factory
+
+	// 	if c.CheckHealth() {
+
+	// 	}
+}
+
+// Put implements DriverPool.Put
+func (bcp *boltConnPool) Put(c Conn) error {
+	if err := c.Close(); err != nil {
+		// remove if we coudln't cleanup properly
+		return bcp.pool.Remove(c, err)
+	}
+	return bcp.pool.Put(c)
+}
+
+// DO all the PG stuff with connection pool handling

--- a/recorder.go
+++ b/recorder.go
@@ -1,4 +1,4 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
 	"bytes"
@@ -8,9 +8,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/encoding"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/log"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/encoding"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/log"
 )
 
 // recorder records a given session with Neo4j.

--- a/result.go
+++ b/result.go
@@ -1,6 +1,6 @@
-package golangNeo4jBoltDriver
+package bolt
 
-import "github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
+import "github.com/axiomzen/golang-neo4j-bolt-driver/errors"
 
 // Result represents a result from a query that returns no data
 type Result interface {

--- a/rows.go
+++ b/rows.go
@@ -1,14 +1,14 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
 	"database/sql/driver"
 	"io"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/encoding"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/log"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/messages"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/encoding"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/log"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/messages"
 )
 
 // Rows represents results of rows from the DB

--- a/stmt.go
+++ b/stmt.go
@@ -1,11 +1,11 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
 	"database/sql/driver"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/log"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/messages"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/log"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/messages"
 )
 
 // Stmt represents a statement to run against the database

--- a/stmt_test.go
+++ b/stmt_test.go
@@ -1,4 +1,4 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
 	"io"
@@ -11,17 +11,19 @@ import (
 
 	"database/sql"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/encoding"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/encoding"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
 )
 
 func TestBoltStmt_SelectOne(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectOne", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -37,8 +39,10 @@ func TestBoltStmt_SelectOne(t *testing.T) {
 	}
 
 	expectedMetadata := map[string]interface{}{
-		"fields": []interface{}{"1"},
+		"result_available_after": rows.Metadata()["result_available_after"],
+		"fields":                 []interface{}{"1"},
 	}
+
 	if !reflect.DeepEqual(rows.Metadata(), expectedMetadata) {
 		t.Fatalf("Unexpected success metadata. Expected %#v. Got: %#v", expectedMetadata, rows.Metadata())
 	}
@@ -53,7 +57,10 @@ func TestBoltStmt_SelectOne(t *testing.T) {
 	}
 
 	_, metadata, err := rows.NextNeo()
-	expectedMetadata = map[string]interface{}{"type": "r"}
+	expectedMetadata = map[string]interface{}{
+		"result_consumed_after": metadata["result_consumed_after"],
+		"type":                  "r",
+	}
 	if err != io.EOF {
 		t.Fatalf("Unexpected row closed output. Expected io.EOF. Got: %s", err)
 	} else if !reflect.DeepEqual(metadata, expectedMetadata) {
@@ -67,12 +74,14 @@ func TestBoltStmt_SelectOne(t *testing.T) {
 }
 
 func TestBoltStmt_SelectMany(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectMany", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -88,8 +97,10 @@ func TestBoltStmt_SelectMany(t *testing.T) {
 	}
 
 	expectedMetadata := map[string]interface{}{
-		"fields": []interface{}{"1", "34234.34323", "\"string\"", "[1, \"2\", 3, true, null]", "true", "null"},
+		"result_available_after": rows.Metadata()["result_available_after"],
+		"fields":                 []interface{}{"1", "34234.34323", "\"string\"", "[1, \"2\", 3, true, null]", "true", "null"},
 	}
+
 	if !reflect.DeepEqual(rows.Metadata(), expectedMetadata) {
 		t.Fatalf("Unexpected success metadata. Expected %#v. Got: %#v", expectedMetadata, rows.Metadata())
 	}
@@ -119,7 +130,11 @@ func TestBoltStmt_SelectMany(t *testing.T) {
 	}
 
 	_, metadata, err := rows.NextNeo()
-	expectedMetadata = map[string]interface{}{"type": "r"}
+	expectedMetadata = map[string]interface{}{
+		"result_consumed_after": metadata["result_consumed_after"],
+		"type":                  "r",
+	}
+
 	if err != io.EOF {
 		t.Fatalf("Unexpected row closed output. Expected io.EOF. Got: %s", err)
 	} else if !reflect.DeepEqual(metadata, expectedMetadata) {
@@ -133,12 +148,14 @@ func TestBoltStmt_SelectMany(t *testing.T) {
 }
 
 func TestBoltStmt_InvalidArgs(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_InvalidArgs", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -170,12 +187,14 @@ func TestBoltStmt_InvalidArgs(t *testing.T) {
 }
 
 func TestBoltStmt_ExecNeo(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_ExecNeo", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -261,12 +280,14 @@ func TestBoltStmt_ExecNeo(t *testing.T) {
 }
 
 func TestBoltStmt_CreateArgs(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_CreateArgs", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -332,12 +353,14 @@ func TestBoltStmt_CreateArgs(t *testing.T) {
 }
 
 func TestBoltStmt_Discard(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_Discard", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -425,12 +448,14 @@ func TestBoltStmt_Discard(t *testing.T) {
 }
 
 func TestBoltStmt_Failure(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_Failure", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -530,12 +555,14 @@ func TestBoltStmt_Failure(t *testing.T) {
 }
 
 func TestBoltStmt_MixedObjects(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_MixedObjects", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -591,12 +618,14 @@ func TestBoltStmt_MixedObjects(t *testing.T) {
 }
 
 func TestBoltStmt_Path(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_Path", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -669,12 +698,14 @@ func TestBoltStmt_Path(t *testing.T) {
 }
 
 func TestBoltStmt_SingleRel(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SingleRel", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -749,12 +780,14 @@ func TestBoltStmt_SingleRel(t *testing.T) {
 }
 
 func TestBoltStmt_SingleNode(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SingleNode", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -829,12 +862,14 @@ func TestBoltStmt_SingleNode(t *testing.T) {
 }
 
 func TestBoltStmt_SelectIntLimits(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectIntLimits", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -905,12 +940,14 @@ func TestBoltStmt_SelectIntLimits(t *testing.T) {
 }
 
 func TestBoltStmt_SelectStringLimits(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectStringLimits", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -966,12 +1003,14 @@ func TestBoltStmt_SelectStringLimits(t *testing.T) {
 }
 
 func TestBoltStmt_SelectSliceLimits(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectSliceLimits", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1033,12 +1072,14 @@ func TestBoltStmt_SelectSliceLimits(t *testing.T) {
 }
 
 func TestBoltStmt_SelectMapLimits(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_SelectMapLimits", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1111,12 +1152,14 @@ func TestBoltStmt_SelectMapLimits(t *testing.T) {
 }
 
 func TestBoltStmt_ManyChunks(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_ManyChunks", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1164,12 +1207,14 @@ func TestBoltStmt_ManyChunks(t *testing.T) {
 }
 
 func TestBoltStmt_PipelineExec(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_PipelineExec", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1291,12 +1336,14 @@ func TestBoltStmt_PipelineExec(t *testing.T) {
 }
 
 func TestBoltStmt_PipelineQuery(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_PipelineQuery", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1411,12 +1458,14 @@ func TestBoltStmt_PipelineQuery(t *testing.T) {
 }
 
 func TestBoltStmt_PipelineQueryCloseBeginning(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_PipelineQueryCloseBeginning", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -1488,12 +1537,14 @@ func TestBoltStmt_PipelineQueryCloseBeginning(t *testing.T) {
 }
 
 func TestBoltStmt_PipelineQueryCloseMiddle(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltStmt_PipelineQueryCloseMiddle", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}

--- a/tx.go
+++ b/tx.go
@@ -1,9 +1,9 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/errors"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/log"
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/messages"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/errors"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/log"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/messages"
 )
 
 // Tx represents a transaction

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,18 +1,21 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/structures/graph"
 	"io"
 	"testing"
+
+	"github.com/axiomzen/golang-neo4j-bolt-driver/structures/graph"
 )
 
 func TestBoltTx_Commit(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltTx_Commit", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}
@@ -97,12 +100,14 @@ func TestBoltTx_Commit(t *testing.T) {
 }
 
 func TestBoltTx_Rollback(t *testing.T) {
-	driver := NewDriver()
+	options := DefaultDriverOptions()
+	options.Addr = neo4jConnStr
+	driver := NewDriverWithOptions(options)
 
 	// Records session for testing
 	driver.(*boltDriver).recorder = newRecorder("TestBoltTx_Rollback", neo4jConnStr)
 
-	conn, err := driver.OpenNeo(neo4jConnStr)
+	conn, err := driver.OpenNeo()
 	if err != nil {
 		t.Fatalf("An error occurred opening conn: %s", err)
 	}

--- a/util.go
+++ b/util.go
@@ -1,11 +1,11 @@
-package golangNeo4jBoltDriver
+package bolt
 
 import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
 
-	"github.com/johnnadratowski/golang-neo4j-bolt-driver/encoding"
+	"github.com/axiomzen/golang-neo4j-bolt-driver/encoding"
 )
 
 // sprintByteHex returns a formatted string of the byte array in hexadecimal


### PR DESCRIPTION
- pulled in the connection pooling from pg (our fork)
- better control over pool configuration

You now just `pool.Get()` and then `pool.Put()` for connections (`pool.Put()` is needed as connections no longer get reclaimed automatically. I may address this in the future)